### PR TITLE
Updating one or more fields on an issue.

### DIFF
--- a/tests/2_functional-tests.js
+++ b/tests/2_functional-tests.js
@@ -349,5 +349,48 @@ suite("Functional Tests", function () {
 				});
 		});
 
+		test("Update multiple fields on an issue", function (done) {
+			this.timeout(10000);
+			const UPDATE_MULTIPLE_FIELDS_REQUEST_BODY = {
+				issue_title: "Issue title modified by PUT request.",
+				issue_text: "Issue text modified by PUT request.",
+				assigned_to: "Angélique",
+			};
+			chai
+				.request(server)
+				.get(PUT_TESTS_URL)
+				.end((err, res) => {
+					// Find the issue's _id to update it
+					const { _id } = res.body[0];
+
+					// Update the issue
+					chai
+						.request(server)
+						.put(PUT_TESTS_URL)
+						.send({ ...UPDATE_MULTIPLE_FIELDS_REQUEST_BODY, _id })
+						.end((err, res) => {
+							// Find the updated issue
+							chai
+								.request(server)
+								.get(PUT_TESTS_URL)
+								.end(function (err, res) {
+									// Check all fields updated have the correct value
+									assert.equal(
+										res.body[0].issue_title,
+										UPDATE_MULTIPLE_FIELDS_REQUEST_BODY.issue_title
+									);
+									assert.equal(
+										res.body[0].issue_text,
+										UPDATE_MULTIPLE_FIELDS_REQUEST_BODY.issue_text
+									);
+									assert.equal(
+										res.body[0].assigned_to,
+										UPDATE_MULTIPLE_FIELDS_REQUEST_BODY.assigned_to
+									);
+								});
+						});
+					done();
+				});
+		});
 	});
 });


### PR DESCRIPTION
- `PUT` tests: added setup and teardown
- Added test: "Update one field" partly fixes #18
- test "Update multiple fields on an issue" partly fixes #18
